### PR TITLE
Adding threshold argument for customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Prerequisites:
 
 To install required libraries, `pip3 install -r requirements.txt` can be run.
 
-To run aws-size, the following command can be run:
+To run aws-size, the following command can be run with aws-size's default configuration:
 
 ```
 python3 aws-size.py --profile <your_profile_here>
@@ -38,6 +38,14 @@ arn:aws:iam::123412341234:policy/<bigpolicy>
 Policy Usage: 90.48%
 Characters Left: 585
 ```
+
+### Customization: Setting Threshold
+
+By default, aws-size reports resources with equal or over than 90% usage.  For customization, aws-size supports the `--threshold` argument.  This argument takes a number between 0 and 1 inclusive to set the threshold of resources for reporting.
+
+For example, setting the threshold to 0.75 will report resources with 75% or more usage.  
+
+If you want to return all resources, set the threshold to 0.  
 
 ## Coverage
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,18 @@ By default, aws-size reports resources with equal or over than 90% usage.  For c
 
 For example, setting the threshold to 0.75 will report resources with 75% or more usage.  
 
-If you want to return all resources, set the threshold to 0.  
+```
+python3 aws-size.py --profile <your_profile_here> --threshold 0.75
+```
+
+If you want to return all resources, set the threshold to 0.  Additionally, threshold can be set to all.
+
+Example commands:
+
+```
+python3 aws-size.py --profile <your_profile_here> --threshold all
+python3 aws-size.py --profile <your_profile_here> --threshold 0
+```
 
 ## Coverage
 

--- a/aws-size.py
+++ b/aws-size.py
@@ -7,6 +7,7 @@ import sys
 parser = argparse.ArgumentParser(prog='IAM Size')
 
 parser.add_argument("--profile")
+parser.add_argument("--threshold", help='Set threshold for reporting (between 0 and 1).  Default is 90%')
 
 args = parser.parse_args()
 

--- a/aws-size.py
+++ b/aws-size.py
@@ -13,10 +13,14 @@ args = parser.parse_args()
 
 try:
     if args.threshold:
-        threshold = float(args.threshold)
-        if threshold > 1 or threshold < 0:
-            print("Threshold must be a number between 0 and 1.  Running aws-size with default of 90%")
-            threshold = 0.90
+        if args.threshold == 'all':
+            threshold = 0
+        else:
+            threshold = float(args.threshold)
+            if threshold > 1 or threshold < 0:
+                print("Threshold must be a number between 0 and 1.  Running aws-size with default of 90%")
+                threshold = 0.90
+            
     else:
         threshold = 0.90
 except: 

--- a/aws-size.py
+++ b/aws-size.py
@@ -74,7 +74,7 @@ for managed_policy in customer_managed_policies:
             'charleft': char_left
         })
 
-        if usage > threshold:
+        if usage >= threshold:
             warning_policies.append({
                 'arn': arn,
                 'name': name,
@@ -87,9 +87,9 @@ for managed_policy in customer_managed_policies:
 
 #Output Section
 print("Customer Managed Policies Scanned: " + str(len(managed_policies_stats)))
-print("Customer Managed Policies with usage over 90%: " + str(len(warning_policies)))
+print(f"Customer Managed Policies with usage over {threshold:.2%} " + str(len(warning_policies)))
 print('\n')
-print("List of policies with more than 90% character usage: ")
+print(f"List of policies with more than {threshold:.2%} character usage: ")
 
 for policy in warning_policies:
     print(policy['arn'])

--- a/aws-size.py
+++ b/aws-size.py
@@ -12,6 +12,18 @@ parser.add_argument("--threshold", help='Set threshold for reporting (between 0 
 args = parser.parse_args()
 
 try:
+    if args.threshold:
+        threshold = float(args.threshold)
+        if threshold > 1 or threshold < 0:
+            print("Threshold must be a number between 0 and 1.  Running aws-size with default of 90%")
+            threshold = 0.90
+    else:
+        threshold = 0.90
+except: 
+    print("Threshold must be a number between 0 and 1.  Running aws-size with default of 90%")
+    threshold = 0.90
+
+try:
     session = boto3.Session(profile_name = args.profile)
     iam_client = session.client('iam')
 except:
@@ -62,7 +74,7 @@ for managed_policy in customer_managed_policies:
             'charleft': char_left
         })
 
-        if usage > 0.90:
+        if usage > threshold:
             warning_policies.append({
                 'arn': arn,
                 'name': name,

--- a/aws-size.py
+++ b/aws-size.py
@@ -71,13 +71,6 @@ for managed_policy in customer_managed_policies:
         usage = round(char_count / 6144, 4)
         char_left = 6144 - len(stripped_str_policy)
 
-        managed_policies_stats.append({
-            'arn': arn,
-            'name': name,
-            'usage': usage,
-            'charleft': char_left
-        })
-
         if usage >= threshold:
             warning_policies.append({
                 'arn': arn,


### PR DESCRIPTION
Adding customization via the threshold argument.

Previously the default threshold for reporting was 90% and was not editable.

This argument `--threshold` takes a number between 0 and 1 (inclusive) that is used to set the threshold.  `--threshold all` can also be used to return all resources (and set threshold to 0).  If unspecified, aws-size will default to 90%.