### PR TITLE
Add IAM Instructions and Reference Policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Prerequisites:
 * Python
 * AWS Credentials
 
+We recommend least privilege when running aws-size and using short-term credentials.  aws-size does not require any sort of write permissions.  AWS provided managed policies that can work with aws-size include ReadOnlyAccess and SecurityAudit.  The ViewOnlyAccess policy does not have the appropriate permissions to view usage of certain resources.  
+
 To install required libraries, `pip3 install -r requirements.txt` can be run.
 
 To run aws-size, the following command can be run:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Prerequisites:
 * Python
 * AWS Credentials
 
-We recommend least privilege when running aws-size and using short-term credentials.  aws-size does not require any sort of write permissions.  AWS provided managed policies that can work with aws-size include ReadOnlyAccess and SecurityAudit.  The ViewOnlyAccess policy does not have the appropriate permissions to view usage of certain resources.  
+We recommend least privilege when running aws-size and using short-term credentials.  aws-size does not require any sort of write permissions.  AWS provided managed policies that can work with aws-size include ReadOnlyAccess and SecurityAudit.  The ViewOnlyAccess policy does not have the appropriate permissions to view usage of certain resources.  An example IAM policy for aws-size can be found [here](iam/aws_size_read_policy.json).
 
 To install required libraries, `pip3 install -r requirements.txt` can be run.
 

--- a/iam/aws_size_read_policy.json
+++ b/iam/aws_size_read_policy.json
@@ -1,0 +1,19 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "AwsSizeReadOnly",
+            "Effect": "Allow",
+            "Action": [
+                "iam:ListPolicies",
+                "iam:GetPolicy",
+                "iam:GetPolicyVersion",
+                "ec2:DescribeInstances",
+                "ec2:DescribeInstanceAttribute",
+                "organizations:ListPolicies",
+                "organizations:DescribePolicy"  
+            ],
+            "Resource": "*"
+        }
+    ]
+}


### PR DESCRIPTION
Add in IAM Instructions for how to run aws-size with a reference IAM policy.