### PR TITLE
Add Ability to save output to a local file

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,36 @@ python3 aws-size.py --profile <your_profile_here> --threshold all
 python3 aws-size.py --profile <your_profile_here> --threshold 0
 ```
 
+### Saving Output to File
+
+aws-size now supports saving the run results to a json file via the `--output` argument. To save, use the `--output` argument followed by the file name. Results are stored with metadata from the run.
+
+Example command:
+```
+python3 aws-size.py --profile <your_profile_here> --threshold 0.75 --output aws-size-output.json
+```
+
+Example of file structure is as follows:
+```
+{
+    "metadata": {
+        "resource": "AWS IAM Managed Policies",
+        "threshold": 0,
+        "timestamp": "2025-08-07 15:35:58"
+    },
+    "results": [
+        {
+            "arn": "arn:aws:iam::123412341234:policy/aws-size-test-policy",
+            "name": "aws-size-test-policy",
+            "usage": 0.0832,
+            "charleft": 5633
+        },
+        ...
+    ]
+}
+```
+
+
 ## Coverage
 
 | Service | Resource | Limit | Limit Size | Service Quota Coverage | Service Quota Visibility | Trusted Advisor Visibility | Adjustable |


### PR DESCRIPTION
This PR adds the abliity to save aws-size's run output to a local flag via the `--output` argument.  This can be done by providing a file name after the argument such as `--output aws-size-output.json`.

README.md has been updated for instructions on how to save output and what metadata is included.